### PR TITLE
Apply themes for client and server projects

### DIFF
--- a/TimeKeeper.Shared/Shared/MainLayout.razor
+++ b/TimeKeeper.Shared/Shared/MainLayout.razor
@@ -1,11 +1,21 @@
 ﻿@inherits LayoutComponentBase
 
-<MudThemeProvider />
+<MudThemeProvider Theme="currentTheme" />
 
 <MudLayout>
     <MudAppBar Elevation="1">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
-        <MudText Typo="Typo.h5" Class="ml-3">Time Keeper</MudText>
+        <MudText Typo="Typo.h5" Class="ml-3">
+            Time Keeper
+            @if (IsWasm)
+            {
+                <span>Client (WASM)</span>
+            }
+            else
+            {
+                <span>Server Side</span>
+            }
+        </MudText>
         <MudAppBarSpacer />
         <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Color="Color.Inherit" Edge="Edge.End" />
     </MudAppBar>

--- a/TimeKeeper.Shared/Shared/MainLayout.razor.cs
+++ b/TimeKeeper.Shared/Shared/MainLayout.razor.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TimeKeeper.Shared.Shared
+{   
+    public partial class MainLayout
+    {
+        [Inject]
+        public NavigationManager MyNavigationManager { get; set; }
+
+        protected bool IsWasm { get; set; } = false;
+
+        protected override void OnInitialized()
+        {
+            currentTheme = defaultTheme;
+
+            IsWasm = MyNavigationManager.Uri.Contains("localhost:44360");
+
+            if(IsWasm)
+            {
+                currentTheme = darkTheme;
+            }
+        }        
+
+        MudTheme currentTheme = new();
+        
+        readonly MudTheme defaultTheme = new()
+        {
+            Palette = new Palette()
+            {
+                Black = "#272c34"
+            }
+        };
+        
+        readonly MudTheme darkTheme = new()
+        {
+            Palette = new Palette()
+            {
+                Black = "#27272f",
+                Background = "#32333d",
+                BackgroundGrey = "#27272f",
+                Surface = "#373740",
+                DrawerBackground = "#27272f",
+                DrawerText = "rgba(255,255,255, 0.50)",
+                DrawerIcon = "rgba(255,255,255, 0.50)",
+                AppbarBackground = "#27272f",
+                AppbarText = "rgba(255,255,255, 0.70)",
+                TextPrimary = "rgba(255,255,255, 0.70)",
+                TextSecondary = "rgba(255,255,255, 0.50)",
+                ActionDefault = "#adadb1",
+                ActionDisabled = "rgba(255,255,255, 0.26)",
+                ActionDisabledBackground = "rgba(255,255,255, 0.12)",
+                Divider = "rgba(255,255,255, 0.12)",
+                DividerLight = "rgba(255,255,255, 0.06)",
+                TableLines = "rgba(255,255,255, 0.12)",
+                LinesDefault = "rgba(255,255,255, 0.12)",
+                LinesInputs = "rgba(255,255,255, 0.3)",
+                TextDisabled = "rgba(255,255,255, 0.2)"
+            }
+        };
+    }
+}


### PR DESCRIPTION
As discussed in issue #51 @harperjohn suggested it would be nice to be able to easily identify whether you were viewing the client (wasm) or server version of the application.

Taking inspiration from https://mudblazor.com/customization/theming/overview I've now set the WASM version to employ a dark theme as shown below.

I currently evaluate whether the application is the client version by the URL which is hard coded to localhost:44360.

In a separate issue / pull request we can look at moving any hardcoded references to localhost to configuration files.

![client-side](https://user-images.githubusercontent.com/52583820/119099579-f48b2400-ba0e-11eb-8eb0-cff44e6b6e1d.png)

![server-side](https://user-images.githubusercontent.com/52583820/119057007-9a18a600-b9c3-11eb-925b-28cf95256967.png)

