### PR TITLE
Retrieve categories from database when adding time entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 /obj
 /TimeKeeper.Shared/bin
 /TimeKeeper.Shared/obj
+**/bin/

--- a/TimeKeeper.Api/Controllers/CategoryController.cs
+++ b/TimeKeeper.Api/Controllers/CategoryController.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MediatR;
+using TimeKeeper.Shared.Api.Features.Category;
+
+namespace TimeKeeper.Api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class CategoryController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public CategoryController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }        
+
+        [HttpGet("GetActive")]
+        public async Task<ActionResult<IEnumerable<GetActive.Model>>> GetActive([FromQuery] GetActive.Query query)
+        {
+            var results = await _mediator.Send(query);
+            return Ok(results);
+        }
+    }
+}

--- a/TimeKeeper.Api/Controllers/TimeEntryController.cs
+++ b/TimeKeeper.Api/Controllers/TimeEntryController.cs
@@ -18,7 +18,7 @@ namespace TimeKeeper.Api.Controllers
         }
 
         [HttpPost]
-        public async Task<ActionResult<int>> Create([FromBody] CreateTimeEntry.Command command)
+        public async Task<ActionResult<int>> Create([FromBody] Create.Command command)
         {
             if (command == null)
             {
@@ -34,8 +34,7 @@ namespace TimeKeeper.Api.Controllers
         }
 
         [HttpGet("GetForSelectedDate")]
-        public async Task<ActionResult<IEnumerable<GetForSelectedDate.Model>>> GetForSelectedDate(
-            [FromQuery] GetForSelectedDate.Query query)
+        public async Task<ActionResult<IEnumerable<GetForSelectedDate.Model>>> GetForSelectedDate([FromQuery] GetForSelectedDate.Query query)
         {
             var results = await _mediator.Send(query);
             return Ok(results);

--- a/TimeKeeper.Api/Data/TimeKeeperContext.cs
+++ b/TimeKeeper.Api/Data/TimeKeeperContext.cs
@@ -7,16 +7,28 @@ namespace TimeKeeper.Api.Data
 {
     public partial class TimeKeeperContext : DbContext
     {
-        public TimeKeeperContext(DbContextOptions options):base(options)
+        public TimeKeeperContext(DbContextOptions options) : base(options)
         {
-           
+
         }
-        
+
+        public virtual DbSet<Category> Categories { get; set; }
         public virtual DbSet<TimeEntry> TimeEntries { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.HasAnnotation("Relational:Collation", "SQL_Latin1_General_CP1_CI_AS");            
+            modelBuilder.HasAnnotation("Relational:Collation", "SQL_Latin1_General_CP1_CI_AS");
+
+            modelBuilder.Entity<Category>(entity =>
+            {
+                entity.Property(e => e.DateCreated).HasColumnType("datetime");
+
+                entity.Property(e => e.DateModified).HasColumnType("datetime");
+
+                entity.Property(e => e.Name)
+                    .IsRequired()
+                    .HasMaxLength(200);
+            });
 
             modelBuilder.Entity<TimeEntry>(entity =>
             {
@@ -29,9 +41,13 @@ namespace TimeKeeper.Api.Data
                 entity.Property(e => e.Notes)
                     .IsRequired()
                     .HasMaxLength(200);
-            });
 
-            OnModelCreatingPartial(modelBuilder);
+                entity.HasOne(d => d.CategoryNavigation)
+                    .WithMany(p => p.TimeEntries)
+                    .HasForeignKey(d => d.Category)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_TimeEntries_Categories");
+            });
         }
 
         partial void OnModelCreatingPartial(ModelBuilder modelBuilder);

--- a/TimeKeeper.Api/Domain/Category.cs
+++ b/TimeKeeper.Api/Domain/Category.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+#nullable disable
+
+namespace TimeKeeper.Api.Domain
+{
+    public partial class Category
+    {
+        public Category()
+        {
+            TimeEntries = new HashSet<TimeEntry>();
+        }
+
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public bool IsActive { get; set; }
+        public DateTime? DateModified { get; set; }
+        public int? ModifiedBy { get; set; }
+        public DateTime DateCreated { get; set; }
+        public int CreatedBy { get; set; }
+
+        public virtual ICollection<TimeEntry> TimeEntries { get; set; }
+    }
+}

--- a/TimeKeeper.Api/Domain/TimeEntry.cs
+++ b/TimeKeeper.Api/Domain/TimeEntry.cs
@@ -19,5 +19,7 @@ namespace TimeKeeper.Api.Domain
         public int? ModifiedBy { get; set; }
         public DateTime DateCreated { get; set; }
         public int CreatedBy { get; set; }
+
+        public virtual Category CategoryNavigation { get; set; }
     }
 }

--- a/TimeKeeper.Api/Features/Category/GetActive.cs
+++ b/TimeKeeper.Api/Features/Category/GetActive.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using TimeKeeper.Api.Data;
+using TimeKeeper.Shared.Api.Features.Category;
+
+namespace TimeKeeper.Api.Features.Category
+{
+    public class GetActiveHandler : IRequestHandler<GetActive.Query, IEnumerable<GetActive.Model>>
+    {
+        private readonly TimeKeeperContext _context;
+
+        public GetActiveHandler(TimeKeeperContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<GetActive.Model>> Handle(GetActive.Query request, CancellationToken cancellationToken)
+        {
+            var categories = await _context.Categories.Where(x => x.IsActive).ToListAsync(cancellationToken: cancellationToken);                       
+
+            return categories.Select(x => new GetActive.Model
+            {
+                Id = x.Id,
+                Name = x.Name
+            });
+        }
+    }
+}

--- a/TimeKeeper.Api/Features/TimeEntry/Create.cs
+++ b/TimeKeeper.Api/Features/TimeEntry/Create.cs
@@ -7,16 +7,16 @@ using TimeKeeper.Shared.Api.Features.TimeEntry;
 
 namespace TimeKeeper.Api.Features.TimeEntry
 {
-    public class CreateTimeEntryHandler : IRequestHandler<CreateTimeEntry.Command, int>
+    public class CreateHandles : IRequestHandler<Create.Command, int>
     {
         private readonly TimeKeeperContext _context;
 
-        public CreateTimeEntryHandler(TimeKeeperContext context)
+        public CreateHandles(TimeKeeperContext context)
         {
             _context = context;
         }
 
-        public async Task<int> Handle(CreateTimeEntry.Command command, CancellationToken cancellationToken)
+        public async Task<int> Handle(Create.Command command, CancellationToken cancellationToken)
         {
             var timeEntry = new Domain.TimeEntry
             {

--- a/TimeKeeper.Api/Features/TimeEntry/GetForSelectedDate.cs
+++ b/TimeKeeper.Api/Features/TimeEntry/GetForSelectedDate.cs
@@ -26,12 +26,11 @@ namespace TimeKeeper.Api.Features.TimeEntry
                          "WHERE [User] = @UserId AND CAST(DateCreated As date) = CAST(@selectedDate As date) " +
                          "ORDER BY DateCreated DESC";
 
-            IEnumerable<Domain.TimeEntry> timeEntries =
-                await _dbConnection.QueryAsync<Domain.TimeEntry>(sql,
+            IEnumerable<Domain.TimeEntry> timeEntries = await _dbConnection.QueryAsync<Domain.TimeEntry>(sql,
                     new
                     {
-                        UserId = request.UserId,
-                        SelectedDate = request.SelectedDate
+                        request.UserId,
+                        request.SelectedDate
                     });
 
             return timeEntries.Select(x => new GetForSelectedDate.Model

--- a/TimeKeeper.Api/Infrastructure/SwaggerExtensions.cs
+++ b/TimeKeeper.Api/Infrastructure/SwaggerExtensions.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+
+namespace TimeKeeper.Api.Infrastructure
+{
+    public static class SwaggerExtensions
+    {
+        public static void ConfigureSwagger(this IServiceCollection services)
+        {
+            string[] reusedNames = {"Command", "Model", "Query"};
+
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo {Title = "TimeKeeper.Api", Version = "v1"});
+                c.CustomSchemaIds(type =>
+                {
+                    if (reusedNames.Any(name => type.FullName.EndsWith($"+{name}")))
+                    {
+                        var parentNamespace =
+                            type.Namespace[(type.Namespace.LastIndexOf(".", StringComparison.Ordinal) + 1)..];
+                        var parentTypeName =
+                            type.FullName[(type.FullName.LastIndexOf(".", StringComparison.Ordinal) + 1)..];
+
+                        parentTypeName = reusedNames.Aggregate(parentTypeName, (current, name) =>
+                            current.Replace($"+{name}", name));
+                        
+                        return $"{parentNamespace}.{parentTypeName}";
+                    }
+
+                    return type.Name;
+                });
+            });
+        }
+    }
+}

--- a/TimeKeeper.Api/Startup.cs
+++ b/TimeKeeper.Api/Startup.cs
@@ -32,9 +32,9 @@ namespace TimeKeeper.Api
             services.AddScoped(_ => new SqlConnection(connectionString));
 
             services.AddMediatR(Assembly.GetExecutingAssembly());
+            
             services.AddControllers(options => { options.Filters.Add<ValidatorActionFilter>(); })
-                .AddFluentValidation(fv =>
-                    fv.RegisterValidatorsFromAssemblyContaining<CreateTimeEntry.CommandValidator>());
+                .AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblyContaining<Create.CommandValidator>());
 
             services.ConfigureSwagger();
         }

--- a/TimeKeeper.Api/Startup.cs
+++ b/TimeKeeper.Api/Startup.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Net.Http.Headers;
-using Microsoft.OpenApi.Models;
 using TimeKeeper.Api.Data;
 using TimeKeeper.Api.Infrastructure;
 using TimeKeeper.Shared.Api.Features.TimeEntry;
@@ -29,20 +28,15 @@ namespace TimeKeeper.Api
         public void ConfigureServices(IServiceCollection services)
         {
             string connectionString = Configuration.GetConnectionString("DefaultConnection");
-            services.AddDbContext<TimeKeeperContext>(options=>options.UseSqlServer(connectionString));
-            services.AddScoped(_=>new SqlConnection(connectionString));
-            
+            services.AddDbContext<TimeKeeperContext>(options => options.UseSqlServer(connectionString));
+            services.AddScoped(_ => new SqlConnection(connectionString));
+
             services.AddMediatR(Assembly.GetExecutingAssembly());
-            services.AddControllers(options =>
-                {
-                    options.Filters.Add<ValidatorActionFilter>();
-                })
-                .AddFluentValidation(fv=>fv.RegisterValidatorsFromAssemblyContaining<CreateTimeEntry.CommandValidator>());
-            
-            services.AddSwaggerGen(c =>
-            {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "TimeKeeper.Api", Version = "v1" });
-            });
+            services.AddControllers(options => { options.Filters.Add<ValidatorActionFilter>(); })
+                .AddFluentValidation(fv =>
+                    fv.RegisterValidatorsFromAssemblyContaining<CreateTimeEntry.CommandValidator>());
+
+            services.ConfigureSwagger();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -59,17 +53,15 @@ namespace TimeKeeper.Api
 
             app.UseRouting();
 
-            app.UseCors(policy => policy.WithOrigins("http://localhost:44360", "https://localhost:44360", "http://localhost:5002", "https://localhost:5003")
-            .AllowAnyMethod()
-            .WithHeaders(HeaderNames.ContentType, HeaderNames.Authorization)
-            .AllowCredentials());
+            app.UseCors(policy => policy.WithOrigins("http://localhost:44360", "https://localhost:44360",
+                    "http://localhost:5002", "https://localhost:5003")
+                .AllowAnyMethod()
+                .WithHeaders(HeaderNames.ContentType, HeaderNames.Authorization)
+                .AllowCredentials());
 
             app.UseAuthorization();
 
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllers();
-            });
+            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
         }
     }
 }

--- a/TimeKeeper.Api/TimeKeeper.Api.csproj
+++ b/TimeKeeper.Api/TimeKeeper.Api.csproj
@@ -10,6 +10,10 @@
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
 

--- a/TimeKeeper.Api/TimeKeeper.Api.csproj.user
+++ b/TimeKeeper.Api/TimeKeeper.Api.csproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Controller_SelectedScaffolderID>ApiControllerEmptyScaffolder</Controller_SelectedScaffolderID>
-    <Controller_SelectedScaffolderCategoryPath>root/Common/Api</Controller_SelectedScaffolderCategoryPath>
+    <Controller_SelectedScaffolderID>MvcControllerEmptyScaffolder</Controller_SelectedScaffolderID>
+    <Controller_SelectedScaffolderCategoryPath>root/Common/MVC/Controller</Controller_SelectedScaffolderCategoryPath>
   </PropertyGroup>
 </Project>

--- a/TimeKeeper.Api/appsettings.json
+++ b/TimeKeeper.Api/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=YOURSQLSERVER;Database=TimeKeeper;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=TimeKeeper;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "Logging": {
     "LogLevel": {

--- a/TimeKeeper.Database/Categories.sql
+++ b/TimeKeeper.Database/Categories.sql
@@ -1,0 +1,10 @@
+﻿CREATE TABLE [dbo].[Categories]
+(
+	[Id] INT NOT NULL PRIMARY KEY IDENTITY, 
+    [Name] NVARCHAR(200) NOT NULL, 
+    [IsActive] BIT NOT NULL, 
+    [DateModified] DATETIME NULL, 
+    [ModifiedBy] INT NULL, 
+    [DateCreated] DATETIME NOT NULL, 
+    [CreatedBy] INT NOT NULL 
+)

--- a/TimeKeeper.Database/SeedData/CategorySeedData.sql
+++ b/TimeKeeper.Database/SeedData/CategorySeedData.sql
@@ -1,0 +1,14 @@
+﻿USE [TimeKeeper]
+GO
+SET IDENTITY_INSERT [dbo].[Categories] ON 
+GO
+INSERT [dbo].[Categories] ([Id], [Name], [IsActive], [DateModified], [ModifiedBy], [DateCreated], [CreatedBy]) VALUES (1, N'Meeting', 1, CAST(N'2021-05-13T00:00:00.000' AS DateTime), 1, CAST(N'2021-05-13T00:00:00.000' AS DateTime), 1)
+GO
+INSERT [dbo].[Categories] ([Id], [Name], [IsActive], [DateModified], [ModifiedBy], [DateCreated], [CreatedBy]) VALUES (2, N'Call', 1, CAST(N'2021-05-13T00:00:00.000' AS DateTime), 1, CAST(N'2021-05-13T00:00:00.000' AS DateTime), 1)
+GO
+INSERT [dbo].[Categories] ([Id], [Name], [IsActive], [DateModified], [ModifiedBy], [DateCreated], [CreatedBy]) VALUES (3, N'Documentation', 1, CAST(N'2021-05-13T00:00:00.000' AS DateTime), 1, CAST(N'2021-05-13T00:00:00.000' AS DateTime), 1)
+GO
+INSERT [dbo].[Categories] ([Id], [Name], [IsActive], [DateModified], [ModifiedBy], [DateCreated], [CreatedBy]) VALUES (4, N'Other', 1, CAST(N'2021-05-13T00:00:00.000' AS DateTime), 1, CAST(N'2021-05-13T00:00:00.000' AS DateTime), 1)
+GO
+SET IDENTITY_INSERT [dbo].[Categories] OFF
+GO

--- a/TimeKeeper.Database/TimeEntries.sql
+++ b/TimeKeeper.Database/TimeEntries.sql
@@ -12,5 +12,6 @@
     [DateModified] DATETIME NULL, 
     [ModifiedBy] INT NULL, 
     [DateCreated] DATETIME NOT NULL, 
-    [CreatedBy] INT NOT NULL 
+    [CreatedBy] INT NOT NULL, 
+    CONSTRAINT [FK_TimeEntries_Categories] FOREIGN KEY ([Category]) REFERENCES [Categories]([Id]) 
 )

--- a/TimeKeeper.Database/TimeKeeper.Database.sqlproj
+++ b/TimeKeeper.Database/TimeKeeper.Database.sqlproj
@@ -56,14 +56,17 @@
   <Import Condition="'$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <ItemGroup>
     <Folder Include="Properties" />
+    <Folder Include="SeedData" />
   </ItemGroup>
   <ItemGroup>
     <Build Include="TimeEntries.sql" />
+    <Build Include="Categories.sql" />
   </ItemGroup>
   <ItemGroup>
     <RefactorLog Include="TimeKeeper.Database.refactorlog" />
   </ItemGroup>
   <ItemGroup>
     <None Include="TimeKeeper.Database.publish.xml" />
+    <None Include="SeedData\CategorySeedData.sql" />
   </ItemGroup>
 </Project>

--- a/TimeKeeper.Shared/Api/Features/Category/GetActive.cs
+++ b/TimeKeeper.Shared/Api/Features/Category/GetActive.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using MediatR;
+
+namespace TimeKeeper.Shared.Api.Features.Category
+{
+    public class GetActive
+    {
+        public record Query : IRequest<IEnumerable<Model>>
+        {
+            
+        }
+
+        public record Model
+        {            
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/TimeKeeper.Shared/Api/Features/Category/GetActive.cs
+++ b/TimeKeeper.Shared/Api/Features/Category/GetActive.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using MediatR;
 
 namespace TimeKeeper.Shared.Api.Features.Category

--- a/TimeKeeper.Shared/Api/Features/TimeEntry/Create.cs
+++ b/TimeKeeper.Shared/Api/Features/TimeEntry/Create.cs
@@ -3,7 +3,7 @@ using MediatR;
 
 namespace TimeKeeper.Shared.Api.Features.TimeEntry
 {
-    public class CreateTimeEntry
+    public class Create
     {
         public class CommandValidator : AbstractValidator<Command>
         {

--- a/TimeKeeper.Shared/Api/ITimeEntryApi.cs
+++ b/TimeKeeper.Shared/Api/ITimeEntryApi.cs
@@ -1,12 +1,16 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Refit;
+using TimeKeeper.Shared.Api.Features.Category;
 using TimeKeeper.Shared.Api.Features.TimeEntry;
 
 namespace TimeKeeper.Shared.Api
 {
     public interface ITimeEntryApi
     {
+        [Get("/api/Category/GetActive")]        
+        Task<IEnumerable<GetActive.Model>> GetActive(GetActive.Query query);
+
         [Get("/api/TimeEntry/GetForSelectedDate")]
         Task<IEnumerable<GetForSelectedDate.Model>> GetForSelectedDate(GetForSelectedDate.Query query);
 
@@ -14,6 +18,6 @@ namespace TimeKeeper.Shared.Api
         Task<int> Create(CreateTimeEntry.Command command);
 
         [Delete("/api/TimeEntry")]
-        Task Delete(Delete.Command command);
+        Task Delete(Delete.Command command);        
     }
 }

--- a/TimeKeeper.Shared/Api/ITimeEntryApi.cs
+++ b/TimeKeeper.Shared/Api/ITimeEntryApi.cs
@@ -15,7 +15,7 @@ namespace TimeKeeper.Shared.Api
         Task<IEnumerable<GetForSelectedDate.Model>> GetForSelectedDate(GetForSelectedDate.Query query);
 
         [Post("/api/TimeEntry")]
-        Task<int> Create(CreateTimeEntry.Command command);
+        Task<int> Create(Create.Command command);
 
         [Delete("/api/TimeEntry")]
         Task Delete(Delete.Command command);        

--- a/TimeKeeper.Shared/Components/AddTimeEntry.razor
+++ b/TimeKeeper.Shared/Components/AddTimeEntry.razor
@@ -20,11 +20,13 @@
 
                 <MudSelect Label="Category" Class="mb-6" @bind-Value="Command.Category">
                     <MudSelectItem Value="0">Please select</MudSelectItem>
-                    <MudSelectItem Value="1">Meeting</MudSelectItem>
-                    <MudSelectItem Value="2">Call</MudSelectItem>
-                    <MudSelectItem Value="3">Documentation</MudSelectItem>
-                    <MudSelectItem Value="4">Travel</MudSelectItem>
-                    <MudSelectItem Value="5">Other</MudSelectItem>
+                    @if (Categories is not null)
+                    {
+                        @foreach (var category in Categories)
+                        {
+                            <MudSelectItem Value="@(category.Id)">@category.Name</MudSelectItem>
+                        }
+                    }
                 </MudSelect>
 
                 <MudItem xs="12" sm="12" md="12" Class="mb-6">

--- a/TimeKeeper.Shared/Components/AddTimeEntry.razor
+++ b/TimeKeeper.Shared/Components/AddTimeEntry.razor
@@ -6,7 +6,7 @@
     <MudCard>
         <MudCardContent>
             <MudText Typo="Typo.h6" GutterBottom="true">Add Time Entry</MudText>
-            <EditForm Model="Command" OnValidSubmit="HandleValidSubmit">
+            <EditForm Model="Command" OnValidSubmit="SaveAsync">
                 <FluentValidationValidator/>
                 <MudSelect Label="Client" Class="mb-6" @bind-Value="Command.Client" For="@(() => Command.Client)">
                     <MudSelectItem Value="0">Please select</MudSelectItem>

--- a/TimeKeeper.Shared/Components/AddTimeEntry.razor.cs
+++ b/TimeKeeper.Shared/Components/AddTimeEntry.razor.cs
@@ -1,19 +1,24 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using TimeKeeper.Shared.Api;
+using TimeKeeper.Shared.Api.Features.Category;
 using TimeKeeper.Shared.Api.Features.TimeEntry;
 
 namespace TimeKeeper.Shared.Components
 {
     public partial class AddTimeEntry
-    {
+    {        
         [Inject] protected ITimeEntryApi TimeEntryApi { get; set; }
+
 
         [Parameter] public EventCallback<string> OnClick { get; set; }
 
         protected CreateTimeEntry.Command Command { get; set; }
 
-        protected override void OnParametersSet()
+        protected IEnumerable<GetActive.Model> Categories { get; set; }
+
+        protected override async Task OnParametersSetAsync()
         {
             //TODO this will be replaced with actual user id once authentication has been implemented.
             var userId = 1;
@@ -21,7 +26,9 @@ namespace TimeKeeper.Shared.Components
             Command = new CreateTimeEntry.Command
             {
                 UserId = userId
-            };
+            };            
+
+            Categories = await TimeEntryApi.GetActive(new GetActive.Query());
         }
 
         protected async Task SaveAsync()

--- a/TimeKeeper.Shared/Components/AddTimeEntry.razor.cs
+++ b/TimeKeeper.Shared/Components/AddTimeEntry.razor.cs
@@ -14,7 +14,7 @@ namespace TimeKeeper.Shared.Components
 
         [Parameter] public EventCallback<string> OnClick { get; set; }
 
-        protected CreateTimeEntry.Command Command { get; set; }
+        protected Create.Command Command { get; set; }
 
         protected IEnumerable<GetActive.Model> Categories { get; set; }
 
@@ -23,7 +23,7 @@ namespace TimeKeeper.Shared.Components
             //TODO this will be replaced with actual user id once authentication has been implemented.
             var userId = 1;
 
-            Command = new CreateTimeEntry.Command
+            Command = new Create.Command
             {
                 UserId = userId
             };            

--- a/TimeKeeper.Shared/Components/ListTimeEntries.razor.cs
+++ b/TimeKeeper.Shared/Components/ListTimeEntries.razor.cs
@@ -3,9 +3,6 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using TimeKeeper.Shared.Api.Features.TimeEntry;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
-using TimeKeeper.Shared.Api;
-using TimeKeeper.Shared.Api.Features.TimeEntry;
 
 namespace TimeKeeper.Shared.Components
 {


### PR DESCRIPTION
Hi @jonhilt

As outlined in [this](https://github.com/BlazingSolutions/TimeKeeper/discussions/61) discussion I've attempted to follow your approach with mediatR/CQRS in order to retrieve categories from the database.

As you'll see I have a few questions and have also managed to break Swagger even if the actual application still works.

Once the Swagger issue is resolved and we're happy I'm following your approach correctly my next goal is to update [ListTimeEntries.razor](https://github.com/BlazingSolutions/TimeKeeper/blob/main/TimeKeeper.Shared/Components/ListTimeEntries.razor) to remove the GetCategoryName method.

We'll remove GetClientName in a separate pull request dealing with reading clients from the database.

Finally, the mediatr-categories has been brought up to date with all the latest changes in main.